### PR TITLE
Automate dismissal of existing runs and unlock state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
       - name: Build and Run Container
         run: |
-          docker build --build-arg TERRAFORM_VERSION=1.2.6 --build-arg IsApply=false --build-arg WorkspaceToDirectory=key:null --build-arg TerraformCloudToken=null --build-arg TerraformCloudOrganization=null -t test-build --file=Dockerfile-test .
+          docker build --build-arg TerraformVersion=1.2.6 --build-arg IsApply=false --build-arg WorkspaceToDirectory=key:null --build-arg TerraformCloudToken=null --build-arg TerraformCloudOrganization=null -t test-build --file=Dockerfile-test .
           docker run test-build
 
   golangci-lint:

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -61,6 +61,9 @@ ENV TERRAFORMCLOUDTOKEN=$TerraformCloudToken
 ARG TerraformCloudOrganization
 ENV TERRAFORMCLOUDORGANIZATION=$TerraformCloudOrganization
 
+ARG TerraformVersion
+ENV TERRAFORMVERSION=$TerraformVersion
+
 ARG WorkspaceToDirectory
 ENV WORKSPACETODIRECTORY=$WorkspaceToDirectory
 

--- a/statemigration/migrateworkspace.go
+++ b/statemigration/migrateworkspace.go
@@ -17,13 +17,13 @@ func (sm *stateMigrator) MigrateAllWorkspaces() error {
 	}
 	fmt.Println("Done creating workspace variable files.")
 
-	for _, directory := range sm.config.WorkspaceToDirectory {
+	for workspace, directory := range sm.config.WorkspaceToDirectory {
 		if directory == "null" {
 			continue
 		}
 
 		fmt.Printf("Beginning to migrate the directory %v\n", directory)
-		err = sm.MigrateWorkspace(WorkspaceDirectory(directory))
+		err = sm.MigrateWorkspace(workspace, WorkspaceDirectory(directory))
 		if err != nil {
 			return fmt.Errorf("[sm.MigrateWorkspace] Error migrating %v workspace: %v", directory, err)
 		}
@@ -35,16 +35,14 @@ func (sm *stateMigrator) MigrateAllWorkspaces() error {
 }
 
 // MigrateWorkspace runs migrations for the workspace specified.
-func (sm *stateMigrator) MigrateWorkspace(w WorkspaceDirectory) error {
-	err := os.Chdir(fmt.Sprintf("/github/workspace%v", string(w)))
+func (sm *stateMigrator) MigrateWorkspace(workspace string, directory WorkspaceDirectory) error {
+	err := os.Chdir(fmt.Sprintf("/github/workspace%v", string(directory)))
 	if err != nil {
 		return fmt.Errorf("[os.Chdir] %v", err)
 	}
 
 	if sm.config.TerraformVersion != "" {
 		tfSwitchArgs := []string{string(sm.config.TerraformVersion)}
-		// TODO: Correctly hitting this use case. Keep getting "No such file or directory" which is problematic.
-		fmt.Printf("Terraform Version has been specified to be %v\n", string(sm.config.TerraformVersion))
 		err = executeCommand("tfswitch", tfSwitchArgs...)
 
 		if err != nil {
@@ -64,13 +62,28 @@ func (sm *stateMigrator) MigrateWorkspace(w WorkspaceDirectory) error {
 		return fmt.Errorf("[executeCommand `terraform init`] %v", err)
 	}
 
-	fmt.Printf("Running migrations for: %v", w)
+	fmt.Printf("Running migrations for: %v", directory)
 
-	tfMigrateArgs := sm.BuildTFMigrateArgs()
+	planOrApply, tfMigrateArgs := sm.BuildTFMigrateArgs()
+
+	if planOrApply == "apply" {
+		err = sm.discardActiveRunsUnlockState()
+		if err != nil {
+			return fmt.Errorf("[sm.clearPendingRunsAndUnlockState`] %v", err)
+		}
+	}
+
 	err = executeCommand("tfmigrate", tfMigrateArgs...)
 
 	if err != nil {
 		return fmt.Errorf("[executeCommand `tfmigrate`] %v", err)
+	}
+
+	if planOrApply == "apply" {
+		err = sm.createPlanOnlyRefreshRun()
+		if err != nil {
+			return fmt.Errorf("[sm.kickOffPlanOnlyRefreshRun`] %v", err)
+		}
 	}
 
 	return nil
@@ -78,7 +91,7 @@ func (sm *stateMigrator) MigrateWorkspace(w WorkspaceDirectory) error {
 
 // BuildTFMigrateArgs constructs a slice of strings for use within
 // a tfmigrate command
-func (sm *stateMigrator) BuildTFMigrateArgs() []string {
+func (sm *stateMigrator) BuildTFMigrateArgs() (string, []string) {
 	var tfMigrateCMD string
 
 	if sm.config.IsApply {
@@ -89,7 +102,7 @@ func (sm *stateMigrator) BuildTFMigrateArgs() []string {
 
 	tfMigrateArgs := []string{tfMigrateCMD, "--config=./dragondrop/tfmigrate/.tfmigrate.hcl"}
 
-	return tfMigrateArgs
+	return tfMigrateCMD, tfMigrateArgs
 }
 
 // executeCommand wraps os.exec.Command with capturing of std output and errors.

--- a/statemigration/migrateworkspace.go
+++ b/statemigration/migrateworkspace.go
@@ -90,7 +90,7 @@ func (sm *stateMigrator) MigrateWorkspace(workspace string, directory WorkspaceD
 	if planOrApply == "apply" {
 		err = sm.createPlanOnlyRefreshRun(ctx, workspaceID)
 		if err != nil {
-			return fmt.Errorf("[sm.kickOffPlanOnlyRefreshRun`] %v", err)
+			return fmt.Errorf("[sm.createPlanOnlyRefreshRun`] %v", err)
 		}
 	}
 

--- a/statemigration/migrateworkspace_test.go
+++ b/statemigration/migrateworkspace_test.go
@@ -12,7 +12,7 @@ func TestBuildTFMigrateArgs(t *testing.T) {
 		},
 	}
 
-	output := sm.BuildTFMigrateArgs()
+	_, output := sm.BuildTFMigrateArgs()
 	expectedOutput := []string{"plan", "--config=./dragondrop/tfmigrate/.tfmigrate.hcl"}
 
 	if !reflect.DeepEqual(output, expectedOutput) {
@@ -25,7 +25,7 @@ func TestBuildTFMigrateArgs(t *testing.T) {
 		},
 	}
 
-	output = sm.BuildTFMigrateArgs()
+	_, output = sm.BuildTFMigrateArgs()
 	expectedOutput = []string{"apply", "--config=./dragondrop/tfmigrate/.tfmigrate.hcl"}
 
 	if !reflect.DeepEqual(output, expectedOutput) {

--- a/statemigration/statemigrator.go
+++ b/statemigration/statemigrator.go
@@ -2,6 +2,7 @@ package statemigration
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/dragondrop-cloud/github-action-tfstate-migration/tfvars"
 )
@@ -25,6 +26,9 @@ type stateMigrator struct {
 	// config is composed of environment variables needed to run StateMigrator methods.
 	config *Config
 
+	// httpClient is an HTTP Client for use in all http calls made by stateMigrator
+	httpClient http.Client
+
 	// tfVar is a struct which can extract the remote variables needed to run migration statements.
 	tfVar tfvars.TFVars
 }
@@ -42,7 +46,8 @@ func NewStateMigrator() (StateMigrator, error) {
 	}
 
 	return &stateMigrator{
-		config: conf,
-		tfVar:  tfVar,
+		config:     conf,
+		httpClient: http.Client{},
+		tfVar:      tfVar,
 	}, nil
 }

--- a/statemigration/statemigrator.go
+++ b/statemigration/statemigrator.go
@@ -16,7 +16,7 @@ type StateMigrator interface {
 	MigrateAllWorkspaces() error
 
 	// MigrateWorkspace runs migrations for the workspace specified.
-	MigrateWorkspace(w WorkspaceDirectory) error
+	MigrateWorkspace(workspace string, directory WorkspaceDirectory) error
 }
 
 // stateMigrator implements the StateMigrator interface.

--- a/statemigration/tfcloud.go
+++ b/statemigration/tfcloud.go
@@ -1,0 +1,62 @@
+package statemigration
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// discardActiveRunsUnlockState identifies pending/active Terraform Cloud runs and discards
+// them so that tfmigrate apply can itself apply a state lock and run migrations.
+func (sm *stateMigrator) discardActiveRunsUnlockState() error {
+
+	return nil
+}
+
+// createPlanOnlyRefreshRun kicks off a new plan-only, refresh-state run for the workspace.
+func (sm *stateMigrator) createPlanOnlyRefreshRun() error {
+
+	return nil
+}
+
+// TODO: needs significant refinement
+// buildTFCloudHTTPRequest structures a request to the Terraform Cloud api.
+func (sm *stateMigrator) buildTFCloudHTTPRequest(ctx context.Context, requestName string, method string, requestPath string) (*http.Request, error) {
+	request, err := http.NewRequestWithContext(ctx, method, requestPath, nil)
+	if err != nil {
+		return nil, fmt.Errorf("[%v] error in http request instantiation: %v", requestName, err)
+	}
+
+	request.Header = http.Header{
+		"Authorization": {"Bearer " + config.TerraformCloudToken},
+		"Content-Type":  {"application/vnd.api+json"},
+	}
+
+	return request, nil
+}
+
+// TODO: needs significant refinement
+// terraformCloudRequest build, executes, and processes an API call to the Terraform Cloud API.
+func (sm *stateMigrator) terraformCloudRequest(, request *http.Request, requestName string) ([]byte, error) {
+
+	response, err := c.httpClient.Do(request)
+
+	if err != nil {
+		return nil, fmt.Errorf("[%v] error in http GET request to Terraform cloud: %v", requestName, err)
+	}
+
+	defer response.Body.Close()
+	if response.StatusCode != 200 {
+		return nil, fmt.Errorf("[%v] was unsuccessful, with the server returning: %v", requestName, response.StatusCode)
+	}
+
+	// Read in response body to bytes array.
+	outputBytes, err := io.ReadAll(response.Body)
+
+	if err != nil {
+		return nil, fmt.Errorf("[%v] error in reading response into bytes array: %v", requestName, err)
+	}
+
+	return outputBytes, nil
+}

--- a/statemigration/tfcloud.go
+++ b/statemigration/tfcloud.go
@@ -5,22 +5,65 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+
+	"github.com/Jeffail/gabs/v2"
 )
+
+// getWorkspaceID gets the workspace ID for the corresponding workspace name
+// from the Terraform Cloud API.
+func (sm *stateMigrator) getWorkspaceID(ctx context.Context, workspace string) (string, error) {
+	requestName := "getWorkspaceID"
+	requestPath := fmt.Sprintf("https://app.terraform.io/api/v2/organizations/%v/workspaces/%v", sm.config.TerraformCloudOrganization, workspace)
+
+	request, err := sm.buildTFCloudHTTPRequest(ctx, requestName, "GET", requestPath)
+
+	if err != nil {
+		return "", fmt.Errorf("[%v] error in newRequest: %v", requestName, err)
+	}
+
+	jsonResponseBytes, err := sm.terraformCloudRequest(request, requestName)
+
+	if err != nil {
+		return "", err
+	}
+
+	return extractWorkspaceID(jsonResponseBytes)
+}
+
+// extractWorkspaceID is a helper function that uses the gabs library to pull out the workspace ID
+// from a Terraform Cloud API response.
+func extractWorkspaceID(jsonBytes []byte) (string, error) {
+	jsonParsed, err := gabs.ParseJSON(jsonBytes)
+	if err != nil {
+		return "", fmt.Errorf("[getWorkspaceID] error in parsing bytes array to json via 'gabs': %v", err)
+	}
+
+	value, ok := jsonParsed.Path("data.id").Data().(string)
+	if !ok {
+		return "", fmt.Errorf("[getWorkspaceID] unable to find workspace id: %v", err)
+	}
+
+	return value, nil
+}
 
 // discardActiveRunsUnlockState identifies pending/active Terraform Cloud runs and discards
 // them so that tfmigrate apply can itself apply a state lock and run migrations.
-func (sm *stateMigrator) discardActiveRunsUnlockState() error {
+func (sm *stateMigrator) discardActiveRunsUnlockState(ctx context.Context, workspaceID string) error {
+	// TODO: First get a list of all active/pending runs
+	// https://developer.hashicorp.com/terraform/cloud-docs/api-docs/run#discard-a-run
 
+	// TODO: For each run in list of active/pending, discard.
+	// https://developer.hashicorp.com/terraform/cloud-docs/api-docs/run#create-a-run
 	return nil
 }
 
 // createPlanOnlyRefreshRun kicks off a new plan-only, refresh-state run for the workspace.
-func (sm *stateMigrator) createPlanOnlyRefreshRun() error {
-
+func (sm *stateMigrator) createPlanOnlyRefreshRun(ctx context.Context, workspaceID string) error {
+	// TODO: Create a plan-only refresh run
+	// https://developer.hashicorp.com/terraform/cloud-docs/api-docs/run#list-runs-in-a-workspace
 	return nil
 }
 
-// TODO: needs significant refinement
 // buildTFCloudHTTPRequest structures a request to the Terraform Cloud api.
 func (sm *stateMigrator) buildTFCloudHTTPRequest(ctx context.Context, requestName string, method string, requestPath string) (*http.Request, error) {
 	request, err := http.NewRequestWithContext(ctx, method, requestPath, nil)
@@ -29,18 +72,17 @@ func (sm *stateMigrator) buildTFCloudHTTPRequest(ctx context.Context, requestNam
 	}
 
 	request.Header = http.Header{
-		"Authorization": {"Bearer " + config.TerraformCloudToken},
+		"Authorization": {"Bearer " + sm.config.TerraformCloudToken},
 		"Content-Type":  {"application/vnd.api+json"},
 	}
 
 	return request, nil
 }
 
-// TODO: needs significant refinement
 // terraformCloudRequest build, executes, and processes an API call to the Terraform Cloud API.
-func (sm *stateMigrator) terraformCloudRequest(, request *http.Request, requestName string) ([]byte, error) {
+func (sm *stateMigrator) terraformCloudRequest(request *http.Request, requestName string) ([]byte, error) {
 
-	response, err := c.httpClient.Do(request)
+	response, err := sm.httpClient.Do(request)
 
 	if err != nil {
 		return nil, fmt.Errorf("[%v] error in http GET request to Terraform cloud: %v", requestName, err)

--- a/statemigration/tfcloud_test.go
+++ b/statemigration/tfcloud_test.go
@@ -1,0 +1,1 @@
+package statemigration

--- a/statemigration/tfcloud_test.go
+++ b/statemigration/tfcloud_test.go
@@ -1,1 +1,100 @@
 package statemigration
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestBuildTFCloudHTTPRequest(t *testing.T) {
+	ctx := context.Background()
+	config := Config{
+		TerraformCloudOrganization: "dragondrop-cloud",
+		TerraformCloudToken:        "example_token",
+		WorkspaceToDirectory:       map[string]string{"workspace_1": "directory_1", "workspace_2": "directory_2"},
+	}
+
+	sm := stateMigrator{
+		config:     &config,
+		httpClient: http.Client{},
+	}
+
+	request, err := sm.buildTFCloudHTTPRequest(
+		ctx, "testRequest", "GET", "https://test.com/",
+	)
+	if err != nil {
+		t.Errorf("Error in buildTFCloudHTTPRequest: %v", err)
+	}
+
+	outputContentType := request.Header.Get("Content-Type")
+	expectedContentType := "application/vnd.api+json"
+	if outputContentType != expectedContentType {
+		t.Errorf("header content type: got %v, expected %v", outputContentType, expectedContentType)
+	}
+
+	outputContentType = request.Header.Get("Authorization")
+	expectedContentType = "Bearer example_token"
+	if outputContentType != expectedContentType {
+		t.Errorf("header authorization: got %v, expected %v", outputContentType, expectedContentType)
+	}
+
+}
+
+func TestExtractWorkspaceID(t *testing.T) {
+	jsonBytes := []byte(`{
+		"data" : {
+			"attributes": {"attribute_1": 10},
+			"id": "8675309"
+		}
+	}`)
+
+	outputValue, err := extractWorkspaceID(jsonBytes)
+	if err != nil {
+		t.Errorf("Unexpectedly failed with %v", err)
+	}
+	expectedValue := "8675309"
+	if outputValue != expectedValue {
+		t.Errorf("Got %v, expected %v", expectedValue, outputValue)
+	}
+}
+
+func TestTerraformCloudRequest(t *testing.T) {
+	ctx := context.Background()
+	mux := http.NewServeMux()
+
+	mux.HandleFunc(
+		"/terraform/cloud/",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`example output`))
+		})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	config := Config{
+		TerraformCloudOrganization: "dragondrop-cloud",
+		TerraformCloudToken:        "example_token",
+		WorkspaceToDirectory:       map[string]string{"workspace_1": "directory_1", "workspace_2": "directory_2"},
+	}
+
+	sm := stateMigrator{
+		config:     &config,
+		httpClient: http.Client{},
+	}
+
+	request, _ := sm.buildTFCloudHTTPRequest(
+		ctx, "testRequest", "GET", server.URL+"/terraform/cloud/",
+	)
+
+	output, err := sm.terraformCloudRequest(request, "testRequest")
+
+	if err != nil {
+		t.Errorf("Was expecting no error, instead received %v", err)
+	}
+
+	if string(output) != "example output" {
+		t.Errorf("Got %v, expected 'example output'", string(output))
+	}
+}

--- a/tfvars/tfcloud.go
+++ b/tfvars/tfcloud.go
@@ -269,7 +269,14 @@ func (tfc *tfCloud) createWorkspaceToVarSetVars(
 ) (map[string]VariableMap, error) {
 	outputWorkspaceToVariable := map[string]VariableMap{}
 
-	for workspace, varSetIDs := range workspaceToVarSetIDs {
+	var workspaceNameList []string
+	for workspace, _ := range workspaceToVarSetIDs {
+		workspaceNameList = append(workspaceNameList, workspace)
+	}
+	sort.Strings(workspaceNameList)
+
+	for _, workspace := range workspaceNameList {
+		varSetIDs := workspaceToVarSetIDs[workspace]
 		currentVarMap := VariableMap{}
 
 		for varSetID := range varSetIDs {

--- a/tfvars/tfcloud.go
+++ b/tfvars/tfcloud.go
@@ -270,7 +270,7 @@ func (tfc *tfCloud) createWorkspaceToVarSetVars(
 	outputWorkspaceToVariable := map[string]VariableMap{}
 
 	var workspaceNameList []string
-	for workspace, _ := range workspaceToVarSetIDs {
+	for workspace := range workspaceToVarSetIDs {
 		workspaceNameList = append(workspaceNameList, workspace)
 	}
 	sort.Strings(workspaceNameList)


### PR DESCRIPTION
When running the CI/CD job, dismiss existing runs and then kick off a refresh-only run.

This case is most useful when git-hooks are set up for on PR merges, and so state may be locked when the CI/CD job tries to run migrations, leading to a failure.